### PR TITLE
Fix recommendations

### DIFF
--- a/spec/recommend-best-move.spec.js
+++ b/spec/recommend-best-move.spec.js
@@ -65,12 +65,24 @@ describe("recommend-best-move", () => {
 
     it("will choose to block a player", () => {
       const board = new Board([
-        'O', '_', '_',
-        'X', 'X', '_',
-        '_', '_', '_',
+        O, _, _,
+        X, X, _,
+        _, _, _,
       ]);
 
       expect(recommendBestMove(board, playerX, playerO)).toBe(position.MIDDLE_RIGHT);
+    });
+  });
+
+  describe("handles example boards", () => {
+    it("🐸", () => {
+      const board = new Board([
+        _, X, X,
+        _, O, _,
+        _, _, _,
+      ]);
+
+      expect(recommendBestMove(board, playerX, playerO)).toBe(position.TOP_LEFT);
     });
   });
 

--- a/spec/recommendations-hash.spec.js
+++ b/spec/recommendations-hash.spec.js
@@ -1,0 +1,45 @@
+const Board = require('../board');
+const recommendationHash = require('../utils/recommendations-hash');
+const Player = require('../player');
+const { playerX, playerO, _ } = require('./stubs/player');
+
+const X = playerX.symbol;
+const O = playerO.symbol;
+
+let allMovesHash;
+
+// the recommendations-hash represents a lot of duplication
+// with recommend-best-move, but these tests provide reassurance
+// for the serialization of recommendations to the hash
+
+describe('recommendations-hash', () => {
+
+  beforeEach(() => {
+    allMovesHash = recommendationHash(Board.generateEmptyBoard(), playerO, playerX);
+  });
+
+  // this test ensures that the human player always gets the first move
+  it("does not have a recommendation for an empty board", () => {
+      const board = [
+        _, _, _,
+        _, _, _,
+        _, _, _
+      ]
+      const recommendation = allMovesHash[new Board(board).toArray().toString()];
+      expect(recommendation).toBe(undefined);
+  });
+
+  describe("blocking sample", () => {
+    it("🐸", () => {
+      const board = [
+        _, X, X,
+        _, _, _,
+        _, O, _
+      ];
+
+      const recommendation = allMovesHash[new Board(board).toArray().toString()];
+      expect(recommendation).toBe(0);
+    });
+  });
+
+});

--- a/spec/score-board.spec.js
+++ b/spec/score-board.spec.js
@@ -14,7 +14,7 @@ describe("score-board", () => {
       O , _ , X ,
     ]);
 
-    expect(scoreBoard(board, playerX, playerX, playerO)).toBe(1);
+    expect(scoreBoard(board, playerX, playerO, playerX)).toBe(1);
   });
 
   it("scores a board resulting in a loss", () => {
@@ -24,7 +24,7 @@ describe("score-board", () => {
       O, _, X,
     ]);
 
-    expect(scoreBoard(board, playerO, playerX, playerO)).toBe(-1);
+    expect(scoreBoard(board, playerO, playerO, playerX)).toBe(-1);
   });
 
   it("scores a board resulting in a draw", () => {

--- a/utils/recommend-best-move.js
+++ b/utils/recommend-best-move.js
@@ -6,10 +6,11 @@ function recommendBestMove(board, previousPlayer, nextPlayer) {
   const emptySpots = board.spotsForSymbol(Board.EMPTY_SPOT_SYMBOL);
 
   // with an empty board, choose the middle
-  if (emptySpots.length === 9) {
+  if (emptySpots.length === board.toArray().length) {
     return 4;
   }
 
+  // find the best move based on scores of available spots
   const bestMove = emptySpots.reduce((bestMove, emptySpot) => {
     const score = scoreBoard(board.makeMove(emptySpot, nextPlayer.symbol), nextPlayer, nextPlayer, previousPlayer);
 
@@ -19,9 +20,18 @@ function recommendBestMove(board, previousPlayer, nextPlayer) {
     };
 
     return bestMove.score > move.score ? bestMove : move;
-  }, {});
+  }, {
+    // set score to ultimately low number so any any
+    // comparison score is greater
+    score: Number.NEGATIVE_INFINITY
+  });
 
-  return bestMove.spot || null;
+  // should have a move with a numbered spot index on the board
+  if (typeof bestMove.spot !== 'number') {
+    throw new Error('Unable to determine a recommended best move for board');
+  }
+
+  return bestMove.spot;
 }
 
 module.exports = memoizeBoardWithPlayers(recommendBestMove);

--- a/utils/recommendations-hash.js
+++ b/utils/recommendations-hash.js
@@ -9,35 +9,42 @@ module.exports = function recommendationHash(board, player, opponent) {
 
   const moveForNode = (node) => {
     const board = node.board;
+
+    // recursive early to determine best moves for children
+    node.children.forEach(node => moveForNode(node));
+
     const hashString = board.toArray().toString();
 
     // hash already exists, no work to be done
     if (hash[hashString]) return;
 
-    node.children.forEach(node => moveForNode(node));
+    const totalMovesMade = board.toArray().filter(
+      spot => spot === player.symbol || spot === opponent.symbol
+    ).length;
+
+
+    if (winnerOfBoard(board)) {
+      hash[hashString] = 'WIN';
+    } else if(totalMovesMade === board.toArray().length) {
+      // the board is completely full
+      hash[hashString] = 'DRAW';
+    }
+
+    if (totalMovesMade % 2 === 0 || totalMovesMade === 0) {
+      // only provide recommendations on moves where the opponent
+      // has already completed their move.
+      return;
+    }
 
     let bestMove;
     try {
       bestMove = recommendBestMove(board, opponent, player);
     } catch (exception) {
-      bestMove = null;
-    }
-
-    const totalMovesMade = board.toArray().filter(
-      spot => spot === player.symbol || spot === opponent.symbol
-    ).length;
-
-    if (winnerOfBoard(board)) {
-      hash[hashString] = 'WIN';
-    } else if (totalMovesMade % 2 === 0) {
-      // only provide recommendations on moves where the opponent
-      // has already completed their move.
+      // skip when unable to determine the best move
       return;
-    } else if (typeof bestMove === 'number') {
-      hash[hashString] = bestMove;
-    } else {
-      hash[hashString] = 'DRAW';
     }
+
+    hash[hashString] = bestMove;
   }
 
   moveForNode(moveTree);


### PR DESCRIPTION
Fix bugs for `recommend-best-move` and `recommendations-hash`

- Recommendation of board index `0` when it was the only recommendation and would fail against the initial reducer's `undefined`.
- Recommendation hash serializing with clearer order of recursion and recommendation states. Included a few tests, too.