### PR TITLE
Add missing responsive meta tag

### DIFF
--- a/src/utils/markup/templates.js
+++ b/src/utils/markup/templates.js
@@ -60,6 +60,7 @@ const containerStart = ({ head }) => `
   <head>
     <title>COPR, CSS Operation Plan Response</title>
     <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     ${head ? head : ""}
   </head>
   <body><div class="window">`;


### PR DESCRIPTION
In order for the responsive styles to be displayed correctly on mobile devices it needed the correct viewport metatag to be added:

`<meta name="viewport" content="width=device-width, initial-scale=1">`