### PR TITLE
Add depth impact to scoreBoard calculation

### DIFF
--- a/spec/recommend-best-move.spec.js
+++ b/spec/recommend-best-move.spec.js
@@ -43,6 +43,13 @@ describe("recommend-best-move", () => {
         position.BOTTOM_LEFT
       );
     });
+
+    it("picks the quickest winning move (edge case)", () => {
+      const board = new Board([X, _, _, _, O, _, X, O, X]);
+      expect(recommendBestMove(board, playerX, playerO)).toBe(
+        position.TOP_MIDDLE
+      );
+    });
   });
 
   describe("follows what I would think is common sense...", () => {

--- a/src/utils/score-board.js
+++ b/src/utils/score-board.js
@@ -12,21 +12,24 @@ function scoreBoard(board, favouredPlayer, previousPlayer, nextPlayer) {
   return recursiveScore(moveTree, favouredPlayer);
 }
 
-function recursiveScore(moveNode, favouredPlayer) {
+function recursiveScore(moveNode, favouredPlayer, depth = 1) {
   const { board, children, nextPlayer } = moveNode;
 
   const winner = winnerOfBoard(board);
   if (winner !== null) {
-    return winner === favouredPlayer.symbol ? POINTS.WIN : POINTS.LOSS;
-  }
+    const points = winner === favouredPlayer.symbol ? POINTS.WIN : POINTS.LOSS;
 
-  if (board.isFull()) {
+    // this takes the points awarded for a win or loss and diminished by depth
+    const depthAdjustedScore = points / depth;
+    return depthAdjustedScore;
+  } else if (board.isFull()) {
     return POINTS.DRAW;
   }
 
   const childrenScores = children.map(node =>
-    recursiveScore(node, favouredPlayer)
+    recursiveScore(node, favouredPlayer, depth + 1)
   );
+
   // maximize for favoured player's turn, minimize for opponent
   const limitingFunction = nextPlayer === favouredPlayer ? Math.max : Math.min;
   return limitingFunction(...childrenScores);


### PR DESCRIPTION
I thought I wanted alpha-beta pruning as mentioned in #3 but what I actually wanted was quicker/smarter wins from the AI, winning in the shortest amount of moves possible. Previously, the AI was presented with a win but would take the long way to the win because the scores were considered equal. This pull request adjusts the win/loss by dividing it by the depth starting with 1. The deeper the depth the smaller the score is worth but because a win is positive and a loss is negative division works well in gauging the depth of the score.